### PR TITLE
Make form-control class optional for input

### DIFF
--- a/DatePicker.php
+++ b/DatePicker.php
@@ -233,6 +233,10 @@ class DatePicker extends InputWidget
                 $this->layout = '{input1}{separator}{input2}';
             }
         }
+     
+        if (empty($this->options['class'])) {
+            Html::addCssClass($this->options, 'form-control');
+        }
         Html::addCssClass($this->options, 'krajee-datepicker');
         $this->options['data-datepicker-source'] = $this->type === self::TYPE_INPUT ? $this->options['id'] :
             $this->_container['id'];
@@ -296,7 +300,6 @@ class DatePicker extends InputWidget
      */
     protected function renderInput()
     {
-        Html::addCssClass($this->options, 'form-control');
         if ($this->type == self::TYPE_INLINE) {
             if (empty($this->options['readonly'])) {
                 $this->options['readonly'] = true;


### PR DESCRIPTION
Do not add form-control class for input if there is already set some in widget options.